### PR TITLE
Add docstrings

### DIFF
--- a/docs/source/en/model_doc/time_series_transformer.mdx
+++ b/docs/source/en/model_doc/time_series_transformer.mdx
@@ -21,13 +21,37 @@ breaking changes to fix it in the future. If you see something strange, file a [
 
 ## Overview
 
-The Time Series Transformer model is a vanilla encoder-decoder Transformer for time series forecasting and classification.
+The Time Series Transformer model is a vanilla encoder-decoder Transformer for time series forecasting.
 
 Tips:
 
-- The model is trained using "teacher-forcing", similar to machine translation. This means that, during training, one provides the ground truth
-previous targets to the model rather than the model's predictions in order to predict the next target. Only at inference time, we sample from the model
-to make a prediction at each time step, which is then fed to the model in order to make the next prediction (also called autoregressive generation).
+- Similar to other models in the library, [`TimeSeriesTransformerModel`] is the raw Transformer without any head on top, and [`TimeSeriesTransformerForPrediction`]
+adds a distribution head on top of the former, which can be used for time-series forecasting. Note that this is a so-called probabilistic forecasting model, not a
+point forecasting model. This means that the model learns a distribution, from which one can sample. The model doesn't directly output values.
+- [`TimeSeriesTransformerForPrediction`] consists of 2 blocks: an encoder, which takes a `context_length` of time series values as input (called `past_values`),
+and a decoder, which predicts a `prediction_length` of time series values into the future (called `future_values`). During training, one needs to provide
+pairs of (`past_values` and `future_values`) to the model.
+- In addition to the raw (`past_values` and `future_values`), one typically provides additional features to the model. These can be the following:
+    - `past_time_features`: temporal features which the model will add to `past_values`. These serve as "positional encodings" for the Transformer encoder.
+    Examples are "day of the month", "month of the year", etc. as scalar values (and then stacked together as a vector).
+    e.g. if a given time-series value was obtained on the 11th of August, then one could have [11, 8] as time feature vector (11 being "day of the month", 8 being "month of the year").
+    - `future_time_features`: temporal features which the model will add to `future_values`. These serve as "positional encodings" for the Transformer decoder.
+    Examples are "day of the month", "month of the year", etc. as scalar values (and then stacked together as a vector).
+    e.g. if a given time-series value was obtained on the 11th of August, then one could have [11, 8] as time feature vector (11 being "day of the month", 8 being "month of the year").
+    - `static_categorical_features`: categorical features which are static over time (i.e., have the same value for all `past_values` and `future_values`).
+    An example here is the store ID or region ID that identifies a given time-series.
+    Note that these features need to be known for ALL data points (also those in the future).
+    - `static_real_features`: real-valued features which are static over time (i.e., have the same value for all `past_values` and `future_values`).
+    An example here is the image representation of the product for which you have the time-series values (like the [ResNet](resnet) embedding of a "shoe" picture,
+    if your time-series is about the sales of shoes).
+    Note that these features need to be known for ALL data points (also those in the future).
+- The model is trained using "teacher-forcing", similar to how a Transformer is trained for machine translation. This means that, during training, one shifts the
+`future_values` one position to the right as input to the decoder, prepended by the last value of `past_values`. At each time step, the model needs to predict the
+next target. So the set-up of training is similar to a GPT model for language, except that there's no notion of `decoder_start_token_id` (we just use the last value
+of the context as initial input for the decoder).
+- At inference time, we give the final value of the `past_values` as input to the decoder. Next, we can sample from the model to make a prediction at the next time step,
+which is then fed to the decoder in order to make the next prediction (also called autoregressive generation).
+
 
 This model was contributed by [kashif](<https://huggingface.co/kashif).
 

--- a/docs/source/en/model_doc/time_series_transformer.mdx
+++ b/docs/source/en/model_doc/time_series_transformer.mdx
@@ -12,6 +12,13 @@ specific language governing permissions and limitations under the License.
 
 # Time Series Transformer
 
+<Tip>
+
+This is a recently introduced model so the API hasn't been tested extensively. There may be some bugs or slight
+breaking changes to fix it in the future. If you see something strange, file a [Github Issue](https://github.com/huggingface/transformers/issues/new?assignees=&labels=&template=bug-report.md&title).
+
+</Tip>
+
 ## Overview
 
 The Time Series Transformer model is a vanilla encoder-decoder Transformer for time series forecasting and classification.

--- a/src/transformers/models/time_series_transformer/configuration_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/configuration_time_series_transformer.py
@@ -23,7 +23,9 @@ from ...utils import logging
 logger = logging.get_logger(__name__)
 
 TIME_SERIES_TRANSFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
-    "huggingface/time-series-transformer-tourism-monthly": "https://huggingface.co/huggingface/time-series-transformer-tourism-monthly/resolve/main/config.json",
+    "huggingface/time-series-transformer-tourism-monthly": (
+        "https://huggingface.co/huggingface/time-series-transformer-tourism-monthly/resolve/main/config.json"
+    ),
     # See all TimeSeriesTransformer models at https://huggingface.co/models?filter=time_series_transformer
 }
 
@@ -33,7 +35,8 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
     This is the configuration class to store the configuration of a [`TimeSeriesTransformerModel`]. It is used to
     instantiate a Time Series Transformer model according to the specified arguments, defining the model architecture.
     Instantiating a configuration with the defaults will yield a similar configuration to that of the Time Series
-    Transformer [huggingface/time-series-transformer-tourism-monthly](https://huggingface.co/huggingface/time-series-transformer-tourism-monthly)
+    Transformer
+    [huggingface/time-series-transformer-tourism-monthly](https://huggingface.co/huggingface/time-series-transformer-tourism-monthly)
     architecture.
 
     Configuration objects inherit from [`PretrainedConfig`] can be used to control the model outputs. Read the
@@ -51,7 +54,8 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
             The loss function for the model corresponding to the `distribution_output` head. For parametric
             distributions it is the negative log likelihood (nll) - which currently is the only supported one.
         input_size (`int`, *optional*, defaults to 1):
-            The size of the target variable which by default is 1 for univariate targets. Would be > 1 in case of multivarate targets. 
+            The size of the target variable which by default is 1 for univariate targets. Would be > 1 in case of
+            multivarate targets.
         scaling (`bool`, *optional* defaults to `True`):
             Whether to scale the input targets.
         lags_sequence (`list[int]`, *optional*, defaults to [1, 2, 3, 4, 5, 6, 7]):
@@ -66,11 +70,13 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
         num_static_real_features (`int`, *optional*, defaults to 0):
             The number of static real valued features.
         cardinality (`list[int]`, *optional*):
-            The cardinality (number of different values) for each of the static categorical features. Should be a list of integers, having the same
-            length as `num_static_categorical_features`. Cannot be `None` if `num_static_categorical_features` is > 0.
+            The cardinality (number of different values) for each of the static categorical features. Should be a list
+            of integers, having the same length as `num_static_categorical_features`. Cannot be `None` if
+            `num_static_categorical_features` is > 0.
         embedding_dimension (`list[int]`, *optional*):
-            The dimension of the embedding for each of the static categorical features. Should be a list of integers, having the same
-            length as `num_static_categorical_features`. Cannot be `None` if `num_static_categorical_features` is > 0.
+            The dimension of the embedding for each of the static categorical features. Should be a list of integers,
+            having the same length as `num_static_categorical_features`. Cannot be `None` if
+            `num_static_categorical_features` is > 0.
         encoder_layers (`int`, *optional*, defaults to 2):
             Number of encoder layers.
         decoder_layers (`int`, *optional*, defaults to 2):
@@ -171,13 +177,18 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
         self.num_static_categorical_features = num_static_categorical_features
         if cardinality and num_static_categorical_features > 0:
             if len(cardinality) != num_static_categorical_features:
-                raise ValueError("The cardinality should be a list having the same length as `num_static_categorical_features`")
+                raise ValueError(
+                    "The cardinality should be a list having the same length as `num_static_categorical_features`"
+                )
             self.cardinality = cardinality
         else:
             self.cardinality = [1]
         if embedding_dimension and num_static_categorical_features > 0:
             if len(embedding_dimension) != num_static_categorical_features:
-                raise ValueError("The embedding dimension should be a list having the same length as `num_static_categorical_features`")
+                raise ValueError(
+                    "The embedding dimension should be a list having the same length as"
+                    " `num_static_categorical_features`"
+                )
             self.embedding_dimension = embedding_dimension
         else:
             self.embedding_dimension = [min(50, (cat + 1) // 2) for cat in self.cardinality]

--- a/src/transformers/models/time_series_transformer/configuration_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/configuration_time_series_transformer.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """ Time Series Transformer model configuration"""
+
 from typing import List, Optional
 
 from ...configuration_utils import PretrainedConfig
@@ -22,7 +23,7 @@ from ...utils import logging
 logger = logging.get_logger(__name__)
 
 TIME_SERIES_TRANSFORMER_PRETRAINED_CONFIG_ARCHIVE_MAP = {
-    "huggingface/tst-ett": "https://huggingface.co/huggingface/tst-ett/resolve/main/config.json",
+    "huggingface/time-series-transformer-tourism-monthly": "https://huggingface.co/huggingface/time-series-transformer-tourism-monthly/resolve/main/config.json",
     # See all TimeSeriesTransformer models at https://huggingface.co/models?filter=time_series_transformer
 }
 
@@ -32,70 +33,72 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
     This is the configuration class to store the configuration of a [`TimeSeriesTransformerModel`]. It is used to
     instantiate a Time Series Transformer model according to the specified arguments, defining the model architecture.
     Instantiating a configuration with the defaults will yield a similar configuration to that of the Time Series
-    Transformer [huggingface/tst-ett](https://huggingface.co/huggingface/tst-ett) architecture.
+    Transformer [huggingface/time-series-transformer-tourism-monthly](https://huggingface.co/huggingface/time-series-transformer-tourism-monthly)
+    architecture.
 
     Configuration objects inherit from [`PretrainedConfig`] can be used to control the model outputs. Read the
     documentation from [`PretrainedConfig`] for more information.
 
     Args:
         prediction_length (`int`):
-            The prediction horizon for the model.
-        context_length (`int`, *optional*):
+            The prediction length for the decoder. In other words, the prediction horizion of the model.
+        context_length (`int`, *optional*, defaults to `prediction_length`):
             The context length for the encoder. If `None`, the context length will be the same as the
             `prediction_length`.
-        distribution_output (`string`, *optional* defaults to `"student_t"`):
-            The distribution emission head for the model.
-        loss (`string`, *optional* defaults to `"nll"`):
+        distribution_output (`string`, *optional*, defaults to `"student_t"`):
+            The distribution emission head for the model. Could be either "student_t", "normal" or "negative_binomial".
+        loss (`string`, *optional*, defaults to `"nll"`):
             The loss function for the model corresponding to the `distribution_output` head. For parametric
-            distributions it is negative log likelihood.
-        input_size (`int`, *optional* defaults to 1):
-            The size of the target variable which by default is 1 for univariate targets.
+            distributions it is the negative log likelihood (nll) - which currently is the only supported one.
+        input_size (`int`, *optional*, defaults to 1):
+            The size of the target variable which by default is 1 for univariate targets. Would be > 1 in case of multivarate targets. 
         scaling (`bool`, *optional* defaults to `True`):
             Whether to scale the input targets.
-        lags_seq (`list[int]`, *optional*, defaults to `[1, 2, 3, 4, 5, 6, 7]`):
+        lags_sequence (`list[int]`, *optional*, defaults to [1, 2, 3, 4, 5, 6, 7]):
             The lags of the input time series as covariates often dictated by the frequency. Default is `[1, 2, 3, 4,
             5, 6, 7]`.
-        num_time_features (`int`, *optional* defaults to 0):
+        num_time_features (`int`, *optional*, defaults to 0):
             The number of time features in the input time series.
-        num_dynamic_real_features (`int`, *optional* defaults to 0):
+        num_dynamic_real_features (`int`, *optional*, defaults to 0):
             The number of dynamic real valued features.
-        num_static_categorical_features (`int`, *optional* defaults to 0):
+        num_static_categorical_features (`int`, *optional*, defaults to 0):
             The number of static categorical features.
-        num_static_real_features (`int`, *optional* defaults to 0):
+        num_static_real_features (`int`, *optional*, defaults to 0):
             The number of static real valued features.
-        cardinality (`list` of `int`, *optional*):
-            The cardinality of the categorical features. Cannot be `None` if `num_static_categorical_features` is `> 0`.
-        embedding_dimension (`list` of `int`, *optional*):
-            The dimension of the embedding for the categorical features. Cannot be `None` if `num_static_categorical_features` is
-            `> 0`.
-        encoder_layers (`int`, *optional*, defaults to `2`):
+        cardinality (`list[int]`, *optional*):
+            The cardinality (number of different values) for each of the static categorical features. Should be a list of integers, having the same
+            length as `num_static_categorical_features`. Cannot be `None` if `num_static_categorical_features` is > 0.
+        embedding_dimension (`list[int]`, *optional*):
+            The dimension of the embedding for each of the static categorical features. Should be a list of integers, having the same
+            length as `num_static_categorical_features`. Cannot be `None` if `num_static_categorical_features` is > 0.
+        encoder_layers (`int`, *optional*, defaults to 2):
             Number of encoder layers.
-        decoder_layers (`int`, *optional*, defaults to `2`):
+        decoder_layers (`int`, *optional*, defaults to 2):
             Number of decoder layers.
-        encoder_attention_heads (`int`, *optional*, defaults to `2`):
+        encoder_attention_heads (`int`, *optional*, defaults to 2):
             Number of attention heads for each attention layer in the Transformer encoder.
-        decoder_attention_heads (`int`, *optional*, defaults to `2`):
+        decoder_attention_heads (`int`, *optional*, defaults to 2):
             Number of attention heads for each attention layer in the Transformer decoder.
-        encoder_ffn_dim (`int`, *optional*, defaults to `32`):
+        encoder_ffn_dim (`int`, *optional*, defaults to 32):
             Dimension of the "intermediate" (often named feed-forward) layer in encoder.
-        decoder_ffn_dim (`int`, *optional*, defaults to `32`):
+        decoder_ffn_dim (`int`, *optional*, defaults to 32):
             Dimension of the "intermediate" (often named feed-forward) layer in decoder.
         activation_function (`str` or `function`, *optional*, defaults to `"gelu"`):
             The non-linear activation function (function or string) in the encoder and decoder. If string, `"gelu"` and
             `"relu"` are supported.
-        dropout (`float`, *optional*, defaults to `0.1`):
+        dropout (`float`, *optional*, defaults to 0.1):
             The dropout probability for all fully connected layers in the encoder, and decoder.
-        encoder_layerdrop (`float`, *optional*, defaults to `0.1`):
+        encoder_layerdrop (`float`, *optional*, defaults to 0.1):
             The dropout probability for the attention and fully connected layers for each encoder layer.
-        decoder_layerdrop (`float`, *optional*, defaults to `0.1`):
+        decoder_layerdrop (`float`, *optional*, defaults to 0.1):
             The dropout probability for the attention and fully connected layers for each decoder layer.
-        attention_dropout (`float`, *optional*, defaults to `0.1`):
+        attention_dropout (`float`, *optional*, defaults to 0.1):
             The dropout probability for the attention probabilities.
-        activation_dropout (`float`, *optional*, defaults to `0.1`):
+        activation_dropout (`float`, *optional*, defaults to 0.1):
             The dropout probability used between the two layers of the feed-forward networks.
-        num_parallel_samples (`int`, *optional*, defaults to `100`):
+        num_parallel_samples (`int`, *optional*, defaults to 100):
             The number of samples to generate in parallel for each time step of inference.
-        init_std (`float`, *optional*, defaults to `0.02`):
+        init_std (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated normal weight initialization distribution.
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether to use the past key/values attentions (if applicable to the model) to speed up decoding.
@@ -105,10 +108,10 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
     ```python
     >>> from transformers import TimeSeriesTransformerConfig, TimeSeriesTransformerModel
 
-    >>> # Initializing a Time Series Transformer huggingface/tst-ett style configuration
+    >>> # Initializing a default Time Series Transformer configuration
     >>> configuration = TimeSeriesTransformerConfig()
 
-    >>> # Initializing a model from the huggingface/tst-ett style configuration
+    >>> # Randomly initializing a model from the configuration
     >>> model = TimeSeriesTransformerModel(configuration)
 
     >>> # Accessing the model configuration
@@ -128,7 +131,7 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
         context_length: Optional[int] = None,
         distribution_output: str = "student_t",
         loss: str = "nll",
-        lags_seq: List[int] = [1, 2, 3, 4, 5, 6, 7],
+        lags_sequence: List[int] = [1, 2, 3, 4, 5, 6, 7],
         scaling: bool = True,
         num_dynamic_real_features: int = 0,
         num_static_categorical_features: int = 0,
@@ -161,17 +164,27 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
         self.loss = loss
         self.input_size = input_size
         self.num_time_features = num_time_features
-        self.lags_seq = lags_seq
+        self.lags_sequence = lags_sequence
         self.scaling = scaling
         self.num_dynamic_real_features = num_dynamic_real_features
         self.num_static_real_features = num_static_real_features
         self.num_static_categorical_features = num_static_categorical_features
-        self.cardinality = cardinality if cardinality and num_static_categorical_features > 0 else [1]
-        self.embedding_dimension = embedding_dimension or [min(50, (cat + 1) // 2) for cat in self.cardinality]
+        if cardinality and num_static_categorical_features > 0:
+            if len(cardinality) != num_static_categorical_features:
+                raise ValueError("The cardinality should be a list having the same length as `num_static_categorical_features`")
+            self.cardinality = cardinality
+        else:
+            self.cardinality = [1]
+        if embedding_dimension and num_static_categorical_features > 0:
+            if len(embedding_dimension) != num_static_categorical_features:
+                raise ValueError("The embedding dimension should be a list having the same length as `num_static_categorical_features`")
+            self.embedding_dimension = embedding_dimension
+        else:
+            self.embedding_dimension = [min(50, (cat + 1) // 2) for cat in self.cardinality]
         self.num_parallel_samples = num_parallel_samples
 
         # Transformer architecture configuration
-        self.d_model = input_size * len(lags_seq) + self._number_of_features
+        self.d_model = input_size * len(lags_sequence) + self._number_of_features
         self.encoder_attention_heads = encoder_attention_heads
         self.decoder_attention_heads = decoder_attention_heads
         self.encoder_ffn_dim = encoder_ffn_dim

--- a/src/transformers/models/time_series_transformer/configuration_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/configuration_time_series_transformer.py
@@ -57,16 +57,16 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
             5, 6, 7]`.
         num_time_features (`int`, *optional* defaults to 0):
             The number of time features in the input time series.
-        num_feat_dynamic_real (`int`, *optional* defaults to 0):
+        num_dynamic_real_features (`int`, *optional* defaults to 0):
             The number of dynamic real valued features.
-        num_feat_static_cat (`int`, *optional* defaults to 0):
+        num_static_categorical_features (`int`, *optional* defaults to 0):
             The number of static categorical features.
-        num_feat_static_real (`int`, *optional* defaults to 0):
+        num_static_real_features (`int`, *optional* defaults to 0):
             The number of static real valued features.
         cardinality (`list` of `int`, *optional*):
-            The cardinality of the categorical features. Cannot be `None` if `num_feat_static_cat` is `> 0`.
+            The cardinality of the categorical features. Cannot be `None` if `num_static_categorical_features` is `> 0`.
         embedding_dimension (`list` of `int`, *optional*):
-            The dimension of the embedding for the categorical features. Cannot be `None` if `num_feat_static_cat` is
+            The dimension of the embedding for the categorical features. Cannot be `None` if `num_static_categorical_features` is
             `> 0`.
         encoder_layers (`int`, *optional*, defaults to `2`):
             Number of encoder layers.
@@ -130,9 +130,9 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
         loss: str = "nll",
         lags_seq: List[int] = [1, 2, 3, 4, 5, 6, 7],
         scaling: bool = True,
-        num_feat_dynamic_real: int = 0,
-        num_feat_static_cat: int = 0,
-        num_feat_static_real: int = 0,
+        num_dynamic_real_features: int = 0,
+        num_static_categorical_features: int = 0,
+        num_static_real_features: int = 0,
         num_time_features: int = 0,
         cardinality: Optional[List[int]] = None,
         embedding_dimension: Optional[List[int]] = None,
@@ -163,10 +163,10 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
         self.num_time_features = num_time_features
         self.lags_seq = lags_seq
         self.scaling = scaling
-        self.num_feat_dynamic_real = num_feat_dynamic_real
-        self.num_feat_static_real = num_feat_static_real
-        self.num_feat_static_cat = num_feat_static_cat
-        self.cardinality = cardinality if cardinality and num_feat_static_cat > 0 else [1]
+        self.num_dynamic_real_features = num_dynamic_real_features
+        self.num_static_real_features = num_static_real_features
+        self.num_static_categorical_features = num_static_categorical_features
+        self.cardinality = cardinality if cardinality and num_static_categorical_features > 0 else [1]
         self.embedding_dimension = embedding_dimension or [min(50, (cat + 1) // 2) for cat in self.cardinality]
         self.num_parallel_samples = num_parallel_samples
 
@@ -199,8 +199,8 @@ class TimeSeriesTransformerConfig(PretrainedConfig):
     def _number_of_features(self) -> int:
         return (
             sum(self.embedding_dimension)
-            + self.num_feat_dynamic_real
+            + self.num_dynamic_real_features
             + self.num_time_features
-            + max(1, self.num_feat_static_real)  # there is at least one dummy static real feature
+            + max(1, self.num_static_real_features)  # there is at least one dummy static real feature
             + 1  # the log(scale)
         )

--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -38,7 +38,6 @@ from .configuration_time_series_transformer import TimeSeriesTransformerConfig
 
 logger = logging.get_logger(__name__)
 
-_CHECKPOINT_FOR_DOC = "huggingface/time-series-transformer-tourism-monthly"
 _CONFIG_FOR_DOC = "TimeSeriesTransformerConfig"
 
 
@@ -1459,7 +1458,7 @@ class TimeSeriesTransformerModel(TimeSeriesTransformerPreTrainedModel):
 
     @property
     def _past_length(self) -> int:
-        return self.config.context_length + max(self.config.lags_seq)
+        return self.config.context_length + max(self.config.lags_sequence)
 
     def get_lagged_subsequences(
         self, sequence: torch.Tensor, subsequences_length: int, shift: int = 0
@@ -1477,7 +1476,7 @@ class TimeSeriesTransformerModel(TimeSeriesTransformerPreTrainedModel):
                 shift the lags by this amount back.
         """
         sequence_length = sequence.shape[1]
-        indices = [lag - shift for lag in self.config.lags_seq]
+        indices = [lag - shift for lag in self.config.lags_sequence]
 
         try:
             assert max(indices) + subsequences_length <= sequence_length, (
@@ -1622,8 +1621,8 @@ class TimeSeriesTransformerModel(TimeSeriesTransformerPreTrainedModel):
         >>> num_time_features = 10
         >>> content_length = 8
         >>> prediction_length = 2
-        >>> lags_seq = [2, 3]
-        >>> past_length = context_length + max(lags_seq)
+        >>> lags_sequence = [2, 3]
+        >>> past_length = context_length + max(lags_sequence)
 
         >>> # encoder inputs
         >>> inputs["static_categorical_features"] = ids_tensor([batch_size, 1], cardinality)
@@ -1728,6 +1727,8 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
 
         if config.loss == "nll":
             self.loss = NegativeLogLikelihood()
+        else:
+            raise ValueError(f"Unknown loss function {config.loss}")
 
         # Initialize weights of distribution_output and apply final processing
         self.post_init()
@@ -1783,8 +1784,8 @@ class TimeSeriesTransformerForPrediction(TimeSeriesTransformerPreTrainedModel):
         >>> num_time_features = 10
         >>> content_length = 8
         >>> prediction_length = 2
-        >>> lags_seq = [2, 3]
-        >>> past_length = context_length + max(lags_seq)
+        >>> lags_sequence = [2, 3]
+        >>> past_length = context_length + max(lags_sequence)
 
         >>> # encoder inputs
         >>> inputs["static_categorical_features"] = ids_tensor([batch_size, 1], cardinality)

--- a/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
+++ b/src/transformers/models/time_series_transformer/modeling_time_series_transformer.py
@@ -932,58 +932,58 @@ TIME_SERIES_TRANSFORMER_START_DOCSTRING = r"""
 
 TIME_SERIES_TRANSFORMER_INPUTS_DOCSTRING = r"""
     Args:
-        past_target (`torch.FloatTensor` of shape `(batch_size, sequence_length)`):
+        past_values (`torch.FloatTensor` of shape `(batch_size, sequence_length)`):
             Past values of the time series, that serve as context in order to predict the future. These values may contain lags,
-            i.e. additional values from the past which are added in order to serve as "extra context". The `past_target` is what
-            the Transformer encoder gets as input (with optional additional features, such as `feat_static_cat`, `feat_static_real`,
-            `past_time_feat`).
+            i.e. additional values from the past which are added in order to serve as "extra context". The `past_values` is what
+            the Transformer encoder gets as input (with optional additional features, such as `static_categorical_features`, `static_real_features`,
+            `past_time_featuresures`).
 
             See the demo notebook and code snippets for details.
 
             Missing values need to be replaced with zeros.
 
-        past_observed_values (`torch.BoolTensor` of shape `(batch_size, sequence_length)`, *optional*):
-            Boolean mask to indicate which `past_target` values were observed and which were missing. Mask values selected in `[0, 1]`:
+        past_observed_mask (`torch.BoolTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Boolean mask to indicate which `past_values` values were observed and which were missing. Mask values selected in `[0, 1]`:
 
             - 1 for values that are **observed**,
-            - 0 for values that are **missing** (i.e. NaNs that were replaced by zeros i).
+            - 0 for values that are **missing** (i.e. NaNs that were replaced by zeros).
 
-        past_time_feat (`torch.FloatTensor` of shape `(batch_size, sequence_length, num_features)`, *optional*):
-            Optional additional features, which the model internally will add to `past_target`. These could be things like "month of year",
+        past_time_featuresures (`torch.FloatTensor` of shape `(batch_size, sequence_length, num_features)`, *optional*):
+            Optional time features, which the model internally will add to `past_values`. These could be things like "month of year",
             "day of the month", etc. encoded as vectors (for instance as Fourier features). These could also be so-called "age" features,
             which basically help the model know "at which point in life" a time-series is. Age features have small values for distant past
             time steps and increase monotonically the more we approach the current time step.
 
             These features serve as the "positional encodings" of the inputs. So contrary to a model like BERT, where the position encodings
-            are learned from scratch internally as parameters of the model, the Time Series Transformer requires to provide additional features.
+            are learned from scratch internally as parameters of the model, the Time Series Transformer requires to provide additional time features.
 
-            The Time Series Transformer only learns additional embeddings for `feat_static_cat`.
+            The Time Series Transformer only learns additional embeddings for `static_categorical_features`.
 
-        feat_static_cat (`torch.LongTensor` of shape `(batch_size, number of static categorical features)`, *optional*):
-            Optional static categorical features for which the model will learn an embedding vector, which it will add to the values
+        static_categorical_features (`torch.LongTensor` of shape `(batch_size, number of static categorical features)`, *optional*):
+            Optional static categorical features for which the model will learn an embedding, which it will add to the values
             of the time series.
 
             Static categorical features are features which have the same value for all time steps (static over time).
 
             A typical example of a static categorical feature is a time series ID.
 
-        feat_static_real (`torch.FloatTensor` of shape `(batch_size, number of static real features)`, *optional*):
+        static_real_features (`torch.FloatTensor` of shape `(batch_size, number of static real features)`, *optional*):
             Optional static real features which the model will add to the values of the time series.
 
             Static real features are features which have the same value for all time steps (static over time).
 
             A typical example of a static real feature is promotion information.
 
-        future_target (`torch.FloatTensor` of shape `(batch_size, prediction_length)`):
-            Future values of the time series, that serve as labels for the model. The `future_target` is what the Transformer
-            needs to learn to output, given the `past_target`.
+        future_values (`torch.FloatTensor` of shape `(batch_size, prediction_length)`):
+            Future values of the time series, that serve as labels for the model. The `future_values` is what the Transformer
+            needs to learn to output, given the `past_values`.
 
             See the demo notebook and code snippets for details.
 
             Missing values need to be replaced with zeros.
 
-        future_time_feat (`torch.FloatTensor` of shape `(batch_size, prediction_length, num_features)`, *optional*):
-            Optional additional features, which the model internally will add to `future_target`. These could be things like "month of year",
+        future_time_featuresures (`torch.FloatTensor` of shape `(batch_size, prediction_length, num_features)`, *optional*):
+            Optional time features, which the model internally will add to `future_values`. These could be things like "month of year",
             "day of the month", etc. encoded as vectors (for instance as Fourier features). These could also be so-called "age" features,
             which basically help the model know "at which point in life" a time-series is. Age features have small values for distant past
             time steps and increase monotonically the more we approach the current time step.
@@ -991,7 +991,7 @@ TIME_SERIES_TRANSFORMER_INPUTS_DOCSTRING = r"""
             These features serve as the "positional encodings" of the inputs. So contrary to a model like BERT, where the position encodings
             are learned from scratch internally as parameters of the model, the Time Series Transformer requires to provide additional features.
 
-            The Time Series Transformer only learns additional embeddings for `feat_static_cat`.
+            The Time Series Transformer only learns additional embeddings for `static_categorical_features`.
 
         head_mask (`torch.Tensor` of shape `(encoder_layers, encoder_attention_heads)`, *optional*):
             Mask to nullify selected heads of the attention modules in the encoder. Mask values selected in `[0, 1]`:

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -58,7 +58,7 @@ class TimeSeriesTransformerModelTester:
         hidden_act="gelu",
         hidden_dropout_prob=0.1,
         attention_probs_dropout_prob=0.1,
-        lags_seq=[1, 2, 3, 4, 5],
+        lags_sequence=[1, 2, 3, 4, 5],
     ):
         self.parent = parent
         self.batch_size = batch_size
@@ -66,7 +66,7 @@ class TimeSeriesTransformerModelTester:
         self.context_length = context_length
         self.cardinality = cardinality
         self.num_time_features = num_time_features
-        self.lags_seq = lags_seq
+        self.lags_sequence = lags_sequence
         self.embedding_dimension = embedding_dimension
         self.is_training = is_training
         self.hidden_size = hidden_size
@@ -82,7 +82,7 @@ class TimeSeriesTransformerModelTester:
         self.decoder_seq_length = prediction_length
 
     def prepare_config_and_inputs(self):
-        _past_length = self.context_length + max(self.lags_seq)
+        _past_length = self.context_length + max(self.lags_sequence)
 
         static_categorical_features = ids_tensor([self.batch_size, 1], self.cardinality)
         static_real_features = floats_tensor([self.batch_size, 1])
@@ -106,7 +106,7 @@ class TimeSeriesTransformerModelTester:
             attention_dropout=self.attention_probs_dropout_prob,
             prediction_length=self.prediction_length,
             context_length=self.context_length,
-            lags_seq=self.lags_seq,
+            lags_sequence=self.lags_sequence,
             num_time_features=self.num_time_features,
             num_static_categorical_features=1,
             cardinality=[self.cardinality],

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -223,12 +223,12 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
 
             expected_arg_names = [
                 "past_values",
-                "static_categorical_features",
-                "static_real_features",
                 "past_time_features",
                 "past_observed_mask",
-                "future_time_features",
+                "static_categorical_features",
+                "static_real_features",
                 "future_values",
+                "future_time_features",
             ]
 
             expected_arg_names.extend(

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -354,9 +354,7 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
 @slow
 class TimeSeriesTransformerModelIntegrationTests(unittest.TestCase):
     def test_inference_no_head(self):
-        model = TimeSeriesTransformerModel.from_pretrained("huggingface/time-series-transformer-tourism-monthly").to(
-            torch_device
-        )
+        # model = TimeSeriesTransformerModel.from_pretrained("huggingface/time-series-transformer-tourism-monthly").to(torch_device)
 
         raise NotImplementedError("To do")
 

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -14,13 +14,11 @@
 # limitations under the License.
 """ Testing suite for the PyTorch TimeSeriesTransformer model. """
 
-import copy
 import inspect
 import tempfile
 import unittest
 
-from transformers import MODEL_MAPPING, is_torch_available
-from transformers.models.auto import get_values
+from transformers import is_torch_available
 from transformers.testing_utils import require_torch, slow, torch_device
 
 from ...test_configuration_common import ConfigTester

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -78,7 +78,6 @@ class TimeSeriesTransformerModelTester:
         self.attention_probs_dropout_prob = attention_probs_dropout_prob
 
         self.encoder_seq_length = context_length
-        self.key_length = context_length
         self.decoder_seq_length = prediction_length
 
     def prepare_config_and_inputs(self):
@@ -260,8 +259,6 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
         seq_len = getattr(self.model_tester, "seq_length", None)
         decoder_seq_length = getattr(self.model_tester, "decoder_seq_length", seq_len)
         encoder_seq_length = getattr(self.model_tester, "encoder_seq_length", seq_len)
-        decoder_key_length = getattr(self.model_tester, "decoder_key_length", decoder_seq_length)
-        encoder_key_length = getattr(self.model_tester, "key_length", encoder_seq_length)
 
         for model_class in self.all_model_classes:
             inputs_dict["output_attentions"] = True
@@ -288,7 +285,7 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
 
             self.assertListEqual(
                 list(attentions[0].shape[-3:]),
-                [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
+                [self.model_tester.num_attention_heads, encoder_seq_length, encoder_seq_length],
             )
             out_len = len(outputs)
 
@@ -314,7 +311,7 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
             self.assertEqual(len(decoder_attentions), self.model_tester.num_hidden_layers)
             self.assertListEqual(
                 list(decoder_attentions[0].shape[-3:]),
-                [self.model_tester.num_attention_heads, decoder_seq_length, decoder_key_length],
+                [self.model_tester.num_attention_heads, decoder_seq_length, decoder_seq_length],
             )
 
             # cross attentions
@@ -326,7 +323,7 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
                 [
                     self.model_tester.num_attention_heads,
                     decoder_seq_length,
-                    encoder_key_length,
+                    encoder_seq_length,
                 ],
             )
 
@@ -346,7 +343,7 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, unittest.TestCase):
         self.assertEqual(len(self_attentions), self.model_tester.num_hidden_layers)
         self.assertListEqual(
             list(self_attentions[0].shape[-3:]),
-            [self.model_tester.num_attention_heads, encoder_seq_length, encoder_key_length],
+            [self.model_tester.num_attention_heads, encoder_seq_length, encoder_seq_length],
         )
 
 


### PR DESCRIPTION
# What does this PR do?

This PR adds docs for the various inputs of the model.

To do:

- [x] rename inputs
- [x] reorder inputs
- [ ] make all inputs optional, except `past_target` perhaps?